### PR TITLE
Update domain name and version number in URLs

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -6,7 +6,7 @@
     "of the License at https://www.gnu.org/licenses/agpl-3.0.en.html"
   ],
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.en10204.io/coa-schemas/v0.0.4/schema.json",
+  "$id": "https://schemas.s1seven.com/coa-schemas/v0.0.4/schema.json",
   "definitions": {
     "Identifier": {
       "title": "Identifier",

--- a/test/fixtures/invalid_certificate_1.json
+++ b/test/fixtures/invalid_certificate_1.json
@@ -1,5 +1,5 @@
 {
-  "RefSchemaUrl": "https://schemas.en10204.io/coa-schemas/v0.0.2/schema.json",
+  "RefSchemaUrl": "https://schemas.s1seven.com/coa-schemas/v0.0.4/schema.json",
   "Certificate": {
     "Id": "certificate_id",
     "Date": "2021-12-01",

--- a/test/fixtures/valid_certificate_1.html
+++ b/test/fixtures/valid_certificate_1.html
@@ -539,7 +539,7 @@
   <footer style="float: left;">
     <p>
       <em class="caption">Powered by <a href="https://en10204.io">en10204.io</a></em>
-      <em style="color:lightgray; margin-left: 35%;" class="caption">https://schemas.en10204.io/coa-schemas/v0.0.2/schema.json</em>
+      <em style="color:lightgray; margin-left: 35%;" class="caption">https://schemas.s1seven.com/coa-schemas/v0.0.4/schema.json</em>
       <br>
     </p>
   </footer>

--- a/test/fixtures/valid_certificate_1.json
+++ b/test/fixtures/valid_certificate_1.json
@@ -1,5 +1,5 @@
 {
-  "RefSchemaUrl": "https://schemas.en10204.io/coa-schemas/v0.0.2/schema.json",
+  "RefSchemaUrl": "https://schemas.s1seven.com/coa-schemas/v0.0.4/schema.json",
   "Certificate": {
     "CertificateLanguages": ["EN", "DE"],
     "Id": "43",


### PR DESCRIPTION
# Description

The move from schemas.en10204.io to schemas.s1seven.com is applied to schema and tests.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] ⚠️ I ensured that the changes to the schema will be compatible with [schema-tools library](https://github.com/s1seven/schema-tools)
